### PR TITLE
fix: ignored config parameter issue

### DIFF
--- a/src/compile/index.js
+++ b/src/compile/index.js
@@ -8,7 +8,7 @@ function Velocity(asts, config) {
     // 不需要转义的白名单
     unescape: {}
   };
-  utils.mixin(config, config);
+  utils.mixin(this.config, config);
   this.init();
 }
 


### PR DESCRIPTION
# Ignored Escaping options bugfix

Hi Sheperdwind

There is a bug inside the constructor for the Compile object, in which **the config parameter object is "ignored"** and not used to extend the original this.config object.

The consequences are that the escape and **unescape options** in the config **doesn't work** ( because they never are updated ).

The fix was made inside the file **src/compile/index.js** line 11

changing `utils.mixin(config, config);` with `utils.mixin(this.config, config);`

Greets

cabumtz
