### PR TITLE
error rendering values as a result of a string function.

### DIFF
--- a/src/compile/references.js
+++ b/src/compile/references.js
@@ -270,9 +270,11 @@ module.exports = function(Velocity, utils) {
 
           var that = this;
 
-          baseRef.eval = function() {
-            return that.eval.apply(that, arguments);
-          };
+          if(typeof baseRef === 'object'){
+            baseRef.eval = function() {
+              return that.eval.apply(that, arguments);
+            };
+          }
 
           try {
             ret = ret.apply(baseRef, args);

--- a/tests/compile.js
+++ b/tests/compile.js
@@ -206,6 +206,13 @@ describe('Compile', function() {
       assert.equal("monica", getContext(vm).monkey.Friend)
       assert.equal("123", getContext(vm).monkey.Number)
     })
+    
+    it('set equal to result of method ', function () {
+      var vm = "#set( $monkey = 'monica' ) ## string literal\n" +
+               '#set( $result = $monkey.substring(1) ) ##calling method'
+      assert.equal("monica", getContext(vm).monkey)
+      assert.equal("onica", getContext(vm).result)
+    })
 
     it('equal to method/property reference', function() {
       var vm = "#set($monkey.Blame = $spindoctor.Leak) ## property \n" +

--- a/tests/compile.js
+++ b/tests/compile.js
@@ -214,6 +214,13 @@ describe('Compile', function() {
       assert.equal("onica", getContext(vm).result)
     })
 
+    it('set equal to result of method ', function () {
+      var vm = "#set( $monkey = 1234 ) ## number literal\n" +
+               '#set( $result = $monkey.toString() ) ##calling method'
+      assert.equal("1234", getContext(vm).monkey)
+      assert.equal("1234", getContext(vm).result)
+    })
+
     it('equal to method/property reference', function() {
       var vm = "#set($monkey.Blame = $spindoctor.Leak) ## property \n" +
                '#set( $monkey.Plan = $spindoctor.weave($web) ) ## method'


### PR DESCRIPTION
If we define as vm that assigns the result of a string function, the render method fails stating this error:

     TypeError: Cannot assign to read only property 'eval' of monica

This happens on references.js, in the getPropMethod. Line 273, when trying to set baseRef.eval property.

This test case highlights the issue.

Other information

node versions I see the issue present itself:
v4.2.1
v3.3.0

It does not seem to happen with node version 0.10.25. Maybe it's a bit more lax regarding this kind of attribution?

Maybe this pull request can help fix the code. I'll take a look at it as well, but I imagine you guys would know best.