### PR TITLE
Add failing test for empty-nest case

### DIFF
--- a/tests/foreach.test.js
+++ b/tests/foreach.test.js
@@ -33,6 +33,20 @@ describe('Loops', function() {
     assert.equal('5432', render(vm))
   })
 
+  it('#foreach with nest non-empty foreach', function() {
+    var vm = '#foreach($i in [1..2])' +
+    '[#foreach($j in [1..2])$j#if($foreach.hasNext),#end#end]' + 
+    '#if($foreach.hasNext),#end#end'
+    assert.equal('[1,2],[1,2]', render(vm))
+  })
+
+  it('#foreach with nest empty foreach', function() {
+    var vm = '#foreach($i in [1..2])' +
+    '[#foreach($j in [])$j#if($foreach.hasNext),#end#end]' + 
+    '#if($foreach.hasNext),#end#end'
+    assert.equal('[],[]', render(vm))
+  })
+
   it('#foreach with map entrySet', function() {
     var vm = '' +
     '#set($js_file = {\n' +


### PR DESCRIPTION
Hi,

I was hoping you could help fix this test case. I'm pretty sure it should pass.

First test passes, 2nd one with the empty nested foreach fails.

I've spent some time trying to figure out how to fix it, but couldn't find a fix.

Thanks,
Russ
