### PR TITLE
fix: keep newline after unparse block

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -28,7 +28,8 @@ var parse = function(str, blocks, ignoreSpace) {
    */
   ignoreSpace || utils.forEach(asts, function trim(ast, i) {
     var TRIM_REG = /^[ \t]*\n/;
-    if (ast.type && ast.type !== 'references') {
+    // after raw and references, then keep the newline.
+    if (ast.type && ['references', 'raw'].indexOf(ast.type) === -1) {
       var _ast = asts[i + 1];
       if (typeof _ast === 'string' && TRIM_REG.test(_ast)) {
         asts[i + 1] = _ast.replace(TRIM_REG, '');

--- a/tests/compile.js
+++ b/tests/compile.js
@@ -685,6 +685,13 @@ describe('Compile', function() {
         val: 'foo'
       }));
     });
+
+    it('newline after', function() {
+      var vm = '#[[This content is ignored. $val]]#\na';
+      assert.equal('This content is ignored. $val\na', render(vm, {
+        val: 'foo'
+      }));
+    });
   });
 
   describe('Object|Array#toString', function() {


### PR DESCRIPTION
fix https://github.com/shepherdwind/velocity.js/pull/82