### PR TITLE
Adding license to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "velocityjs",
   "description": "Velocity Template Language(VTL) for JavaScript",
   "version": "0.9.6",
+  "license": "MIT",
   "keywords": [
     "velocity template"
   ],


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the package.json it becomes available through the public NPMRegistry API and that way other tools like VersionEye can fetch it easier.