### PR TITLE
Make sure to also escape quotes

### DIFF
--- a/src/compile/references.js
+++ b/src/compile/references.js
@@ -30,6 +30,9 @@ module.exports = function(Velocity, utils) {
         if (c === '&') {
           cstr = "&amp;"
           escape = true
+        } else if (c === '"') {
+          cstr = "&quot;"
+          escape = true
         } else if (c === '<') {
           cstr = "&lt;"
           escape = true


### PR DESCRIPTION
Imagine a case where a stringified json is inlined as a data attribute, in this case the " must be escaped, too, in order to maintain valid html