### PR TITLE
Fix issue with loop variable access inside nested foreach statements.

### DIFF
--- a/src/compile/set.js
+++ b/src/compile/set.js
@@ -10,7 +10,7 @@ module.exports = function(Velocity, utils) {
       var condition = this.condition;
       var local = this.local;
       if (condition) {
-        return local[condition];
+        return Object.assign(this.context, local[condition]);
       } else {
         return this.context;
       }

--- a/test/foreach.test.js
+++ b/test/foreach.test.js
@@ -162,4 +162,42 @@ describe('Loops', function() {
     const ret2 = render(template2, context);
     ret2.trim().should.equal('[{ID=1, key=1}, {ID=2, key=2}, {ID=3, key=3}]');
   });
+
+  it('nested foreach subprop', function() {
+    var tpl = `
+      #set($list = [{"prop": "a"}])
+      #set($list2 = ["a", "b", "c"])
+      #foreach($i in $list)
+          #set($fc = $velocityCount - 1)
+          #foreach($j in $list2)
+              #set($i.prop = "$i.prop$j")
+          #end
+      #end
+      $list
+    `
+    var ret = render(tpl).trim()
+    assert.equal('[{prop=aabc}]', ret);
+  })
+
+  it('nested foreach set', function() {
+    var tpl = `
+      #set($obj = [{
+        "SubProp": [
+          { "SubSubProp": "a" }
+        ]
+      }])
+      #set($subSubPropRealValue = "b")
+      #foreach($sub in $obj)
+          #set($fc = $velocityCount - 1)
+          #foreach($subsub in $sub.SubProp)
+              #set($fcc = $velocityCount - 1)
+              #set($sub.SubProp[$fcc].SubSubProp = $subSubPropRealValue)
+          #end
+          #set($obj[$fc] = $sub)
+      #end
+      $obj
+    `
+    var ret = render(tpl).trim()
+    assert.equal('[{SubProp=[{SubSubProp=b}]}]', ret);
+  })
 })


### PR DESCRIPTION
Accessing and updating loop variables in a nested foreach does not update the value outside. 

Here are 2 scenarios I came across where this was happening:

```
it('nested foreach subprop', function() {
    var tpl = `
      #set($list = [{"prop": "a"}])
      #set($list2 = ["a", "b", "c"])
      #foreach($i in $list)
          #set($fc = $velocityCount - 1)
          #foreach($j in $list2)
              #set($i.prop = "$i.prop$j")
          #end
      #end
      $list
    `
    var ret = render(tpl).trim()
    assert.equal('[{prop=aabc}]', ret);
  })

  it('nested foreach set', function() {
    var tpl = `
      #set($obj = [{
        "SubProp": [
          { "SubSubProp": "a" }
        ]
      }])
      #set($subSubPropRealValue = "b")
      #foreach($sub in $obj)
          #set($fc = $velocityCount - 1)
          #foreach($subsub in $sub.SubProp)
              #set($fcc = $velocityCount - 1)
              #set($sub.SubProp[$fcc].SubSubProp = $subSubPropRealValue)
          #end
          #set($obj[$fc] = $sub)
      #end
      $obj
    `
    var ret = render(tpl).trim()
    assert.equal('[{SubProp=[{SubSubProp=b}]}]', ret);
  })
```

This seems to be because the foreach loop variables are only stored in the `local` store and not the global context so the nested foreach does not have access to them. 

I'm not sure the following solution is the correct one, but updating the `src/compile/set.js:getContext` method to merge the local context and the global context seems to fix this issue by making the loop variable available in the global context for the next statements to use.

Thank you for this amazing package, it's been super useful to our team!


