### PR TITLE
Addressing #140, also added a bit more defensive code in case pos is missing in error situations

### DIFF
--- a/src/compile/blocks.js
+++ b/src/compile/blocks.js
@@ -187,7 +187,9 @@ module.exports = function(Velocity, utils) {
     getBlockEach: function(block) {
 
       var ast = block[0];
-      var _from = this.getLiteral(ast.from);
+      var tFrom = {};
+      Object.assign(tFrom, ast.from, {pos: ast.pos});
+      var _from = this.getLiteral(tFrom);
       var _block = block.slice(1);
       var _to = ast.to;
       var local = {

--- a/src/compile/references.js
+++ b/src/compile/references.js
@@ -79,6 +79,8 @@ module.exports = function(Velocity, utils) {
     return base[property];
   }
 
+  var posUnknown = { first_line: "unknown", first_column: "unknown"};
+
   utils.mixin(Velocity.prototype, {
     /**
      * get variable value 
@@ -312,7 +314,7 @@ module.exports = function(Velocity, utils) {
           try {
             ret = ret.apply(baseRef, args);
           } catch (e) {
-            var pos = ast.pos;
+            var pos = ast.pos || posUnknown;
             var text = Velocity.Helper.getRefText(ast);
             var err = ' on ' + text + ' at L/N ' +
               pos.first_line + ':' + pos.first_column;
@@ -336,7 +338,7 @@ module.exports = function(Velocity, utils) {
       }
 
       var text = Velocity.Helper.getRefText(ast);
-      var pos = ast.pos;
+      var pos = ast.pos || posUnknown;
       var propertyName = property.type === 'index' ? property.id.value : property.id;
       var errorMsg = 'get property ' + propertyName + ' of undefined';
       if (errorName === 'TypeError') {

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -212,7 +212,7 @@ describe('Compile', function() {
   })
 
   describe('throw friendly error message', function() {
-    it('print right posiont when error throw', function() {
+    it('prints the right position when error thrown', function() {
       var vm = '111\nsdfs\n$foo($name)'
 
       var compile = new Compile(parse(vm), { escape: false })
@@ -229,6 +229,29 @@ describe('Compile', function() {
       assert.throws(function() {
         compile.render(context)
       }, /L\/N 3:0/)
+    })
+
+    it('prints the right position when error thrown in foreach', function() {
+      var vm = `
+      #foreach( $item in $func() )
+      #end
+      `
+
+      var compile = new Compile(parse(vm), { escape: false })
+      var context = {
+        name: '<i>',
+        func: function() {
+          throw new Error('Run error')
+        }
+      }
+
+      assert.throws(function() {
+        compile.render(context)
+      }, /\$func\(\)/)
+
+      assert.throws(function() {
+        compile.render(context)
+      }, /L\/N 2:6/)
     })
 
     it('print error stack of user-defined macro', function() {


### PR DESCRIPTION
I wasn't sure how to adjust pos for this situation to point to the correct location unfortunately
But otherwise I believe this at least gives a better error message

I suspect you should be able to call a function inside of a #foreach block, but this commit only allows better error handling