### PR TITLE
feat: Add default export for CommonJS/ESM compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,18 +5,24 @@ import { getRefText } from './helper/index';
 
 // Compile.parse = parse;
 
-export const render = (
-  template: string,
-  context?: RenderContext,
-  macros?: Macros,
-  config?: CompileConfig
-): string => {
-  const asts = parse(template);
-  const compile = new Compile(asts, config);
-  return compile.render(context, macros);
+const velocity = {
+  render: (
+    template: string,
+    context?: RenderContext,
+    macros?: Macros,
+    config?: CompileConfig
+  ): string => {
+    const asts = parse(template);
+    const compile = new Compile(asts, config);
+    return compile.render(context, macros);
+  },
+  parse: parse,
+  Compile: Compile,
+  Helper: {
+    getRefText,
+  },
 };
 
-export const Helper = {
-  getRefText,
-};
-export { parse, Compile };
+export { parse, Compile, velocity };
+export const Helper = velocity.Helper;
+export default velocity;


### PR DESCRIPTION
This pull request introduces a default export to the velocity.js library. This change enhances compatibility with environments that expect a default export when using ECMAScript Module (ESM) import syntax (import ... from ...).

Motivation:

Currently, velocity.js primarily exports its functionalities (render, parse, Compile, Helper) as named exports using CommonJS (module.exports). While this works well in CommonJS environments, it causes issues in ESM contexts where a default export is expected for the import ... from ... syntax.