### PR TITLE
fix: block prototype-polluting set paths

### DIFF
--- a/src/compile/set.ts
+++ b/src/compile/set.ts
@@ -1,4 +1,4 @@
-import type { Attribute, ReferencesAST, SetAST, VELOCITY_AST } from '../type';
+import type { ReferencesAST, SetAST, VELOCITY_AST } from '../type';
 import { applyMixins } from '../utils';
 import { Compile } from './base-compile';
 
@@ -27,18 +27,6 @@ export class SetValue extends Compile {
     // not find local variable, return global context
     return this.context;
   }
-  private getPathKey(exp: Attribute): string {
-    if (exp.type === 'property') {
-      return exp.id;
-    }
-
-    if (exp.type === 'index' && exp.id) {
-      return String(this.getLiteral(exp.id as VELOCITY_AST));
-    }
-
-    return '';
-  }
-
   private hasPollutingPropertyPath(ref: ReferencesAST): boolean {
     return Boolean(ref.path?.some((exp) => exp.type === 'property' && isPollutingKey(exp.id)));
   }
@@ -84,18 +72,26 @@ export class SetValue extends Compile {
     (context as Record<string, unknown>)[ref.id] = baseRef;
     const len = ref.path ? ref.path.length : 0;
 
-    for (let i = 0; i < len; i++) {
-      const exp = ref.path[i];
-      const key = this.getPathKey(exp);
+    ref.path.some((exp, i) => {
       const isEnd = len === i + 1;
+      let key: string;
+
+      if (exp.type === 'property') {
+        key = exp.id;
+      } else if (exp.type === 'index' && exp.id) {
+        key = String(this.getLiteral(exp.id as VELOCITY_AST));
+      } else {
+        key = '';
+      }
 
       if (isPollutingKey(key)) {
-        return;
+        // Return true to stop Array.prototype.some traversal without assigning.
+        return true;
       }
 
       if (isEnd) {
         (baseRef as Record<string, unknown>)[key] = val;
-        return;
+        return true;
       }
 
       baseRef = (baseRef as Record<string, unknown>)[key] as Record<string, unknown>;
@@ -104,9 +100,11 @@ export class SetValue extends Compile {
       // #set($a.d.c2 = 2)
       // but $a.d is undefined, value set fail
       if (baseRef === undefined) {
-        return;
+        return true;
       }
-    }
+
+      return false;
+    });
   }
 }
 

--- a/src/compile/set.ts
+++ b/src/compile/set.ts
@@ -84,17 +84,18 @@ export class SetValue extends Compile {
     (context as Record<string, unknown>)[ref.id] = baseRef;
     const len = ref.path ? ref.path.length : 0;
 
-    ref.path.some((exp, i) => {
+    for (let i = 0; i < len; i++) {
+      const exp = ref.path[i];
       const key = this.getPathKey(exp);
       const isEnd = len === i + 1;
 
       if (isPollutingKey(key)) {
-        return true;
+        return;
       }
 
       if (isEnd) {
         (baseRef as Record<string, unknown>)[key] = val;
-        return true;
+        return;
       }
 
       baseRef = (baseRef as Record<string, unknown>)[key] as Record<string, unknown>;
@@ -103,11 +104,9 @@ export class SetValue extends Compile {
       // #set($a.d.c2 = 2)
       // but $a.d is undefined, value set fail
       if (baseRef === undefined) {
-        return true;
+        return;
       }
-
-      return false;
-    });
+    }
   }
 }
 

--- a/src/compile/set.ts
+++ b/src/compile/set.ts
@@ -1,4 +1,4 @@
-import type { SetAST, VELOCITY_AST } from '../type';
+import type { Attribute, ReferencesAST, SetAST, VELOCITY_AST } from '../type';
 import { applyMixins } from '../utils';
 import { Compile } from './base-compile';
 
@@ -27,11 +27,32 @@ export class SetValue extends Compile {
     // not find local variable, return global context
     return this.context;
   }
+  private getPathKey(exp: Attribute): string {
+    if (exp.type === 'property') {
+      return exp.id;
+    }
+
+    if (exp.type === 'index' && exp.id) {
+      return String(this.getLiteral(exp.id as VELOCITY_AST));
+    }
+
+    return '';
+  }
+
+  private hasPollutingPropertyPath(ref: ReferencesAST): boolean {
+    return Boolean(ref.path?.some((exp) => exp.type === 'property' && isPollutingKey(exp.id)));
+  }
+
   /**
    * parse #set
    */
   setValue(ast: SetAST): void {
     const ref = ast.equal[0];
+
+    if (isPollutingKey(ref.id) || this.hasPollutingPropertyPath(ref)) {
+      return;
+    }
+
     let context = this.getContext(ref.id) as object;
 
     // @see #25
@@ -50,10 +71,6 @@ export class SetValue extends Compile {
       val = this.config.valueMapper?.(this.getLiteral(ast.equal[1]));
     }
 
-    if (isPollutingKey(ref.id)) {
-      return;
-    }
-
     if (!ref.path) {
       (context as Record<string, unknown>)[ref.id] = val;
       return;
@@ -68,16 +85,8 @@ export class SetValue extends Compile {
     const len = ref.path ? ref.path.length : 0;
 
     ref.path.some((exp, i) => {
+      const key = this.getPathKey(exp);
       const isEnd = len === i + 1;
-      let key: string;
-
-      if (exp.type === 'property') {
-        key = exp.id;
-      } else if (exp.type === 'index' && exp.id) {
-        key = String(this.getLiteral(exp.id as VELOCITY_AST));
-      } else {
-        key = '';
-      }
 
       if (isPollutingKey(key)) {
         return true;

--- a/src/compile/set.ts
+++ b/src/compile/set.ts
@@ -1,6 +1,13 @@
 import type { SetAST, VELOCITY_AST } from '../type';
 import { applyMixins } from '../utils';
 import { Compile } from './base-compile';
+
+const POLLUTING_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isPollutingKey(key: string): boolean {
+  return POLLUTING_KEYS.has(key);
+}
+
 /**
  * #set value
  */
@@ -43,6 +50,10 @@ export class SetValue extends Compile {
       val = this.config.valueMapper?.(this.getLiteral(ast.equal[1]));
     }
 
+    if (isPollutingKey(ref.id)) {
+      return;
+    }
+
     if (!ref.path) {
       (context as Record<string, unknown>)[ref.id] = val;
       return;
@@ -66,6 +77,10 @@ export class SetValue extends Compile {
         key = String(this.getLiteral(exp.id as VELOCITY_AST));
       } else {
         key = '';
+      }
+
+      if (isPollutingKey(key)) {
+        return true;
       }
 
       if (isEnd) {

--- a/test/set.test.ts
+++ b/test/set.test.ts
@@ -190,6 +190,31 @@ describe('Set && Expression', function () {
     });
   });
 
+  describe('prototype pollution protection', function () {
+    afterEach(function () {
+      delete (Object.prototype as Record<string, unknown>).polluted;
+      delete (Object.prototype as Record<string, unknown>).isAdmin;
+    });
+
+    it('does not set values through __proto__ references', function () {
+      render('#set($__proto__.polluted = "hacked")', {});
+
+      assert.equal(({} as Record<string, unknown>).polluted, undefined);
+    });
+
+    it('does not set values through constructor.prototype paths', function () {
+      render('#set($target.constructor.prototype.isAdmin = true)', { target: {} });
+
+      assert.equal(({} as Record<string, unknown>).isAdmin, undefined);
+    });
+
+    it('does not set prototype-polluting index keys', function () {
+      render('#set($target["__proto__"].polluted = "hacked")', { target: {} });
+
+      assert.equal(({} as Record<string, unknown>).polluted, undefined);
+    });
+  });
+
   it('set with foreach', function () {
     const tpl = `
 #foreach($item in [1..2])

--- a/test/set.test.ts
+++ b/test/set.test.ts
@@ -213,6 +213,20 @@ describe('Set && Expression', function () {
 
       assert.equal(({} as Record<string, unknown>).polluted, undefined);
     });
+
+    it('does not evaluate assigned values for prototype-polluting paths', function () {
+      let evaluated = false;
+
+      render('#set($__proto__.polluted = $markEvaluated())', {
+        markEvaluated() {
+          evaluated = true;
+          return 'hacked';
+        },
+      });
+
+      assert.equal(evaluated, false);
+      assert.equal(({} as Record<string, unknown>).polluted, undefined);
+    });
   });
 
   it('set with foreach', function () {


### PR DESCRIPTION
### Motivation
- Prevent prototype pollution when rendering attacker-controlled templates that use `#set` to write properties like `__proto__`, `constructor`, or `prototype` into object paths.
- The `#set` implementation resolved and wrote path segments without guarding prototype-polluting keys, allowing modifications to `Object.prototype` in the running process.

### Description
- Add a denylist `POLLUTING_KEYS = new Set(['__proto__','constructor','prototype'])` and helper `isPollutingKey` in `src/compile/set.ts` to detect dangerous keys.
- Short-circuit `#set` writes when the root reference (`ref.id`) or any resolved path segment matches a polluting key to avoid writing into prototype properties.
- Add regression tests in `test/set.test.ts` to cover `__proto__`, `constructor.prototype`, and index-based `"__proto__"` pollution attempts.
- Modified files: `src/compile/set.ts` and `test/set.test.ts`.

### Testing
- Ran linting with `npm run lint` and it completed successfully.
- Ran unit tests with `npm test -- --runInBand` and all test suites passed (`175 passed, 175 total`), including the new prototype protection tests.
- Ran the build-and-test flow with `npm run test:build` and the build + build-tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad8337b04832d8d1919486ebed7bf)