### PR TITLE
ci: drop Node.js 18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "vite-plugin-dts": "^4.5.3"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git://github.com/shepherdwind/velocity.js.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.19.0"
   },
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.mjs",


### PR DESCRIPTION
## What changed

- Remove Node.js 18 from the GitHub Actions matrix.
- Raise the declared minimum Node.js version from 16 to 20.19 in `package.json` and `package-lock.json`.
- Keep the existing Vite 8.0.16 dependency unchanged.

## Why

Vite 8 requires Node.js 20.19+ or 22.12+. The Node.js 18 CI job failed during `vite build` with `ReferenceError: CustomEvent is not defined`. The project no longer needs to support older Node.js releases, so the CI matrix and package metadata should reflect the supported runtime range.

## Validation

- `npm ci`
- `npm run ci`
- 11 test suites / 189 tests passed
- CommonJS and ESM build tests passed